### PR TITLE
Fix Docker deployment for Traefik reverse proxy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
 
+RUN npx drizzle-kit generate
 RUN npm run build
 
 # ─── Production ───────────────────────────────────────────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,45 @@ services:
     build: .
     container_name: cancer-card
     restart: unless-stopped
-    ports:
-      - "3000:3000"
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.cancer-card.rule=Host(`${SUBDOMAIN}.${DOMAIN}`)
+      - traefik.http.routers.cancer-card.tls=true
+      - traefik.http.routers.cancer-card.entrypoints=web,websecure
+      - traefik.http.routers.cancer-card.tls.certresolver=mytlschallenge
+      - traefik.http.services.cancer-card.loadbalancer.server.port=3000
+      - traefik.http.middlewares.cancer-card.headers.SSLRedirect=true
+      - traefik.http.middlewares.cancer-card.headers.STSSeconds=315360000
+      - traefik.http.middlewares.cancer-card.headers.browserXSSFilter=true
+      - traefik.http.middlewares.cancer-card.headers.contentTypeNosniff=true
+      - traefik.http.middlewares.cancer-card.headers.forceSTSHeader=true
+      - traefik.http.middlewares.cancer-card.headers.SSLHost=${DOMAIN}
+      - traefik.http.middlewares.cancer-card.headers.STSIncludeSubdomains=true
+      - traefik.http.middlewares.cancer-card.headers.STSPreload=true
+      - traefik.http.routers.cancer-card.middlewares=cancer-card@docker
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://0.0.0.0:3000/"]
+      interval: 30s
+      timeout: 3s
+      start_period: 10s
+      retries: 3
     volumes:
       - cancer_card_data:/data
     environment:
       - NODE_ENV=production
       - DATABASE_PATH=/data/app.db
       - AUTH_SECRET=${AUTH_SECRET}
-      - AUTH_URL=${AUTH_URL:-http://localhost:3000}
+      - AUTH_URL=${AUTH_URL}
       - RESEND_API_KEY=${RESEND_API_KEY}
-      - EMAIL_FROM=${EMAIL_FROM:-noreply@localhost}
-      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      - EMAIL_FROM=${EMAIL_FROM}
+      - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
+    networks:
+      - web
 
 volumes:
   cancer_card_data:
     driver: local
+
+networks:
+  web:
+    external: true

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,7 @@ const loginSchema = z.object({
 });
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  trustHost: true,
   providers: [
     Credentials({
       name: "credentials",


### PR DESCRIPTION
## Summary
- **Dockerfile**: Add `drizzle-kit generate` to builder stage — the `drizzle/` directory isn't committed to the repo, so the `COPY --from=builder /app/drizzle` step fails without this
- **docker-compose.yml**: Replace `ports: 3000:3000` with Traefik labels, external `web` network, security headers, and a healthcheck override (`http://0.0.0.0:3000/` instead of `http://localhost:3000/`)
- **auth.ts**: Add `trustHost: true` for Auth.js v5 running behind a reverse proxy

## Why the healthcheck matters
Next.js standalone binds to `0.0.0.0` (set via `HOSTNAME` env), not `127.0.0.1`. The Dockerfile healthcheck uses `wget http://localhost:3000/` which silently fails, leaving the container permanently in `health: starting` status. Traefik v3 filters out containers that aren't healthy — so the app runs fine but Traefik returns 404.

## Test plan
- [ ] `docker compose up -d --build` completes without errors
- [ ] Container reaches `(healthy)` status within 30s
- [ ] Traefik routes traffic to the app (no 404)
- [ ] Login/signup flows work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)