### PR TITLE
feat: add notification system database schema

### DIFF
--- a/drizzle/0001_add_notification_tables.sql
+++ b/drizzle/0001_add_notification_tables.sql
@@ -1,0 +1,63 @@
+-- Add notification system tables
+-- Migration: 0001_add_notification_tables
+
+CREATE TABLE `notification_preferences` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`crew_id` text NOT NULL,
+	`enable_push` integer DEFAULT true NOT NULL,
+	`enable_email` integer DEFAULT true NOT NULL,
+	`enable_sms` integer DEFAULT false NOT NULL,
+	`sms_phone_number` text,
+	`event_preferences` text DEFAULT '{"task_created":{"push":true,"email":true,"sms":false},"task_assigned":{"push":true,"email":true,"sms":true},"task_claimed":{"push":true,"email":true,"sms":false},"task_completed":{"push":true,"email":true,"sms":false},"task_cancelled":{"push":true,"email":false,"sms":false},"member_joined":{"push":true,"email":false,"sms":false},"milestone_logged":{"push":false,"email":false,"sms":false},"streak_bonus":{"push":true,"email":true,"sms":false}}',
+	`quiet_hours_enabled` integer DEFAULT true NOT NULL,
+	`quiet_hours_start` text DEFAULT '22:00',
+	`quiet_hours_end` text DEFAULT '08:00',
+	`timezone` text DEFAULT 'America/New_York',
+	`enable_weekly_digest` integer DEFAULT true NOT NULL,
+	`digest_day` text DEFAULT 'sunday',
+	`digest_time` text DEFAULT '09:00',
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE cascade,
+	FOREIGN KEY (`crew_id`) REFERENCES `crews`(`id`) ON DELETE cascade
+);
+
+CREATE UNIQUE INDEX `user_crew_prefs_unique` ON `notification_preferences` (`user_id`, `crew_id`);
+
+CREATE TABLE `notification_log` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`crew_id` text NOT NULL,
+	`event_type` text NOT NULL,
+	`channel` text NOT NULL,
+	`recipient_email` text,
+	`recipient_phone` text,
+	`recipient_push_token` text,
+	`title` text NOT NULL,
+	`body` text NOT NULL,
+	`data` text,
+	`status` text NOT NULL,
+	`error_message` text,
+	`external_id` text,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`sent_at` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE cascade,
+	FOREIGN KEY (`crew_id`) REFERENCES `crews`(`id`) ON DELETE cascade
+);
+
+CREATE TABLE `push_tokens` (
+	`id` text PRIMARY KEY NOT NULL,
+	`user_id` text NOT NULL,
+	`token` text NOT NULL,
+	`platform` text NOT NULL,
+	`device_model` text,
+	`device_name` text,
+	`app_version` text,
+	`is_active` integer DEFAULT true NOT NULL,
+	`last_used` integer DEFAULT (unixepoch()) NOT NULL,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE cascade
+);
+
+CREATE UNIQUE INDEX `push_tokens_token_unique` ON `push_tokens` (`token`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1770771989831,
       "tag": "0000_large_randall",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1771894800000,
+      "tag": "0001_add_notification_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -228,6 +228,170 @@ export const taskMenuTemplates = sqliteTable("task_menu_templates", {
 
 // ─── Self-Care Routine Definitions ───────────────────────────────────────────
 
+// ─── Notification Preferences ────────────────────────────────────────────────
+
+export type ChannelToggles = {
+  push: boolean;
+  email: boolean;
+  sms: boolean;
+};
+
+export type EventPreferences = {
+  task_created: ChannelToggles;
+  task_assigned: ChannelToggles;
+  task_claimed: ChannelToggles;
+  task_completed: ChannelToggles;
+  task_cancelled: ChannelToggles;
+  member_joined: ChannelToggles;
+  milestone_logged: ChannelToggles;
+  streak_bonus: ChannelToggles;
+};
+
+const defaultEventPreferences: EventPreferences = {
+  task_created: { push: true, email: true, sms: false },
+  task_assigned: { push: true, email: true, sms: true },
+  task_claimed: { push: true, email: true, sms: false },
+  task_completed: { push: true, email: true, sms: false },
+  task_cancelled: { push: true, email: false, sms: false },
+  member_joined: { push: true, email: false, sms: false },
+  milestone_logged: { push: false, email: false, sms: false },
+  streak_bonus: { push: true, email: true, sms: false },
+};
+
+export const notificationPreferences = sqliteTable(
+  "notification_preferences",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    crewId: text("crew_id")
+      .notNull()
+      .references(() => crews.id, { onDelete: "cascade" }),
+
+    // Global channel toggles (per crew)
+    enablePush: integer("enable_push", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    enableEmail: integer("enable_email", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    enableSms: integer("enable_sms", { mode: "boolean" })
+      .notNull()
+      .default(false),
+
+    // SMS contact (if SMS enabled)
+    smsPhoneNumber: text("sms_phone_number"), // E.164 format: +12345678900
+
+    // Per-event preferences (JSON)
+    eventPreferences: text("event_preferences", { mode: "json" })
+      .$type<EventPreferences>()
+      .default(defaultEventPreferences),
+
+    // Quiet hours (local timezone)
+    quietHoursEnabled: integer("quiet_hours_enabled", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    quietHoursStart: text("quiet_hours_start").default("22:00"),
+    quietHoursEnd: text("quiet_hours_end").default("08:00"),
+    timezone: text("timezone").default("America/New_York"),
+
+    // Digest preferences
+    enableWeeklyDigest: integer("enable_weekly_digest", { mode: "boolean" })
+      .notNull()
+      .default(true),
+    digestDay: text("digest_day").default("sunday"),
+    digestTime: text("digest_time").default("09:00"),
+
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .notNull()
+      .default(sql`(unixepoch())`),
+  },
+  (table) => [
+    uniqueIndex("user_crew_prefs_unique").on(table.userId, table.crewId),
+  ]
+);
+
+// ─── Notification Log ────────────────────────────────────────────────────────
+
+export const notificationLog = sqliteTable("notification_log", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+  crewId: text("crew_id")
+    .notNull()
+    .references(() => crews.id, { onDelete: "cascade" }),
+
+  // Notification metadata
+  eventType: text("event_type").notNull(),
+  channel: text("channel", { enum: ["push", "email", "sms"] }).notNull(),
+
+  // Delivery details
+  recipientEmail: text("recipient_email"),
+  recipientPhone: text("recipient_phone"),
+  recipientPushToken: text("recipient_push_token"),
+
+  // Content
+  title: text("title").notNull(),
+  body: text("body").notNull(),
+  data: text("data", { mode: "json" }).$type<Record<string, unknown>>(),
+
+  // Status tracking
+  status: text("status", {
+    enum: ["pending", "sent", "failed", "skipped"],
+  }).notNull(),
+  errorMessage: text("error_message"),
+
+  // External IDs (for tracking)
+  externalId: text("external_id"),
+
+  // Timestamps
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+  sentAt: integer("sent_at", { mode: "timestamp" }),
+});
+
+// ─── Push Tokens ─────────────────────────────────────────────────────────────
+
+export const pushTokens = sqliteTable("push_tokens", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  userId: text("user_id")
+    .notNull()
+    .references(() => users.id, { onDelete: "cascade" }),
+
+  // Token details
+  token: text("token").notNull().unique(),
+  platform: text("platform", { enum: ["ios", "android", "web"] }).notNull(),
+
+  // Device info (optional, for debugging)
+  deviceModel: text("device_model"),
+  deviceName: text("device_name"),
+  appVersion: text("app_version"),
+
+  // Status
+  isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
+  lastUsed: integer("last_used", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+
+  createdAt: integer("created_at", { mode: "timestamp" })
+    .notNull()
+    .default(sql`(unixepoch())`),
+});
+
+// ─── Self-Care Routine Definitions ───────────────────────────────────────────
+
 export const selfCareRoutines = sqliteTable("self_care_routines", {
   id: text("id")
     .primaryKey()


### PR DESCRIPTION
## Summary

Adds the foundational database schema for the Cancer Card notification system.

### Changes
- 3 new tables in `src/db/schema.ts`:
  - `notification_preferences` — per-user event + channel toggles
  - `notification_log` — delivery tracking and audit trail
  - `push_tokens` — device push token storage
- Migration SQL: `drizzle/0001_add_notification_tables.sql`
- TypeScript types exported: `EventPreferences`, `ChannelToggles`

### Context
This is PR 1 of the notification system buildout (PRs 2-11 planned). Schema only — no runtime changes.

### Testing
- Types compile cleanly
- Migration SQL reviewed for correctness