### PR TITLE
feat: Auction closing mechanics — deadline, auto-close, and manual winner selection

### DIFF
--- a/drizzle/0002_auction_close.sql
+++ b/drizzle/0002_auction_close.sql
@@ -1,0 +1,11 @@
+-- Migration: Auction Closing Mechanics
+-- Description: This migration documents the auction closing feature.
+-- No schema changes required as endsAt is already part of the auctionSettings JSON column.
+-- 
+-- Changes:
+-- - Auction duration is now configurable in the UI (30min to 24hr)
+-- - Auctions auto-close when endsAt is reached
+-- - Card Holders can manually close auctions and select winners
+-- - New API endpoints: POST /api/tasks/[id]/close-auction and GET /api/tasks/[id]/check-auction
+--
+-- No SQL changes needed.

--- a/src/app/(main)/play-card/page.tsx
+++ b/src/app/(main)/play-card/page.tsx
@@ -52,6 +52,15 @@ const URGENCY_OPTIONS = [
   { value: "asap", label: "ASAP", color: "text-danger" },
 ] as const;
 
+const AUCTION_DURATION_OPTIONS = [
+  { value: 30, label: "30 min" },
+  { value: 60, label: "1 hr" },
+  { value: 120, label: "2 hr" },
+  { value: 240, label: "4 hr" },
+  { value: 480, label: "8 hr" },
+  { value: 1440, label: "24 hr" },
+] as const;
+
 export default function PlayCardPage() {
   const router = useRouter();
   const { addToast } = useToast();
@@ -71,6 +80,7 @@ export default function PlayCardPage() {
   const [mode, setMode] = useState<"direct" | "open" | "auction">("open");
   const [urgency, setUrgency] = useState<"whenever" | "today" | "asap">("whenever");
   const [pointCost, setPointCost] = useState(25);
+  const [auctionDuration, setAuctionDuration] = useState(60);
 
   useEffect(() => {
     fetch("/api/menu")
@@ -114,7 +124,7 @@ export default function PlayCardPage() {
           urgency,
           auctionSettings:
             mode === "auction"
-              ? { minBid: 5, durationMinutes: 60, autoCloseAfterBids: null }
+              ? { minBid: 5, durationMinutes: auctionDuration, autoCloseAfterBids: null }
               : undefined,
         }),
       });
@@ -314,6 +324,30 @@ export default function PlayCardPage() {
                 ))}
               </div>
             </div>
+
+            {/* Auction Duration (only for auction mode) */}
+            {mode === "auction" && (
+              <div>
+                <p className="font-heading font-bold text-midnight mb-2">
+                  Auction duration
+                </p>
+                <div className="grid grid-cols-3 gap-2">
+                  {AUCTION_DURATION_OPTIONS.map((opt) => (
+                    <button
+                      key={opt.value}
+                      onClick={() => setAuctionDuration(opt.value)}
+                      className={`py-2 rounded-button text-sm font-heading font-semibold transition-all min-h-[44px] min-w-0 ${
+                        auctionDuration === opt.value
+                          ? "bg-royal text-white"
+                          : "bg-royal-50 text-royal"
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {/* Urgency */}
             <div>

--- a/src/app/(main)/tasks/[id]/page.tsx
+++ b/src/app/(main)/tasks/[id]/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowLeft, Gavel, CheckCircle, UserCheck, Clock } from "lucide-react";
+import { ArrowLeft, Gavel, CheckCircle, UserCheck, Clock, Award } from "lucide-react";
 import { Card, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -53,21 +53,62 @@ export default function TaskDetailPage() {
   const [bidAmount, setBidAmount] = useState("");
   const [bidComment, setBidComment] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
+  const [selectedBidId, setSelectedBidId] = useState<string | null>(null);
+  const [showWinnerSelect, setShowWinnerSelect] = useState(false);
+  const [isCardHolder, setIsCardHolder] = useState(false);
 
   function fetchTask() {
     fetch(`/api/tasks?status=`)
       .then((r) => r.json())
       .then((data) => {
         const found = data.tasks?.find((t: TaskDetail) => t.id === id);
-        if (found) setTask(found);
+        if (found) {
+          setTask(found);
+          // Calculate time remaining for auction
+          if (found.requestMode === "auction" && found.auctionSettings?.endsAt) {
+            const endsAt = new Date(found.auctionSettings.endsAt);
+            const remaining = Math.max(0, endsAt.getTime() - Date.now());
+            setTimeRemaining(remaining);
+          }
+        }
         setLoading(false);
       })
       .catch(() => setLoading(false));
+
+    // Fetch user role
+    fetch("/api/crews")
+      .then((r) => r.json())
+      .then((data) => {
+        const activeCrew = data.crews?.find((c: any) => c.id === data.activeCrewId);
+        if (activeCrew?.role === "card_holder" || activeCrew?.role === "admin") {
+          setIsCardHolder(true);
+        }
+      })
+      .catch(() => {});
   }
 
   useEffect(() => {
     fetchTask();
   }, [id]);
+
+  // Countdown timer for auctions
+  useEffect(() => {
+    if (timeRemaining === null || timeRemaining <= 0) return;
+
+    const interval = setInterval(() => {
+      setTimeRemaining((prev) => {
+        if (prev === null || prev <= 1000) {
+          // Auction ended, refresh task
+          fetchTask();
+          return 0;
+        }
+        return prev - 1000;
+      });
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [timeRemaining]);
 
   useSSE({
     url: "/api/feed/stream",
@@ -144,6 +185,70 @@ export default function TaskDetailPage() {
     setSubmitting(false);
   }
 
+  async function handleCloseAuctionAuto() {
+    setSubmitting(true);
+    vibrate("medium");
+
+    try {
+      const res = await fetch(`/api/tasks/${id}/close-auction`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "auto" }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error);
+      }
+      vibrate("success");
+      addToast("success", "Auction closed! Lowest bidder wins.");
+      fetchTask();
+    } catch (error) {
+      addToast("error", error instanceof Error ? error.message : "Failed to close auction");
+    }
+    setSubmitting(false);
+  }
+
+  async function handleSelectWinner() {
+    if (!selectedBidId) return;
+    setSubmitting(true);
+    vibrate("medium");
+
+    try {
+      const res = await fetch(`/api/tasks/${id}/close-auction`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "select", bidId: selectedBidId }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error);
+      }
+      vibrate("success");
+      addToast("success", "Winner selected!");
+      setShowWinnerSelect(false);
+      setSelectedBidId(null);
+      fetchTask();
+    } catch (error) {
+      addToast("error", error instanceof Error ? error.message : "Failed to select winner");
+    }
+    setSubmitting(false);
+  }
+
+  function formatTimeRemaining(ms: number): string {
+    const totalSeconds = Math.floor(ms / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    } else if (minutes > 0) {
+      return `${minutes}m ${seconds}s`;
+    } else {
+      return `${seconds}s`;
+    }
+  }
+
   if (loading || !task) {
     return (
       <div className="px-4 pt-6 max-w-lg mx-auto">
@@ -153,6 +258,9 @@ export default function TaskDetailPage() {
   }
 
   const lowestBid = task.bids.length > 0 ? task.bids[0].bidAmount : task.pointCost;
+  const auctionExpired = task.requestMode === "auction" && 
+    task.auctionSettings?.endsAt && 
+    new Date(task.auctionSettings.endsAt) < new Date();
 
   return (
     <div className="px-4 pt-6 max-w-lg mx-auto space-y-4">
@@ -258,6 +366,24 @@ export default function TaskDetailPage() {
             <CardTitle>Reverse Auction</CardTitle>
           </div>
 
+          {/* Countdown Timer */}
+          {timeRemaining !== null && timeRemaining > 0 && (
+            <div className="flex items-center gap-2 mb-3 bg-royal-50 rounded-lg p-3">
+              <Clock className="w-4 h-4 text-royal" />
+              <span className="text-sm font-semibold text-royal">
+                {formatTimeRemaining(timeRemaining)} remaining
+              </span>
+            </div>
+          )}
+
+          {auctionExpired && (
+            <div className="mb-3 bg-warning-50 rounded-lg p-3">
+              <p className="text-sm font-semibold text-warning">
+                ⏰ Auction ended
+              </p>
+            </div>
+          )}
+
           <p className="text-sm text-muted mb-3">
             Current lowest bid: <strong className="text-royal font-mono">{lowestBid} pts</strong>
           </p>
@@ -271,7 +397,10 @@ export default function TaskDetailPage() {
                   initial={{ opacity: 0, x: -10 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: i * 0.05 }}
-                  className="flex items-center gap-2 bg-surface rounded-lg p-2"
+                  className={`flex items-center gap-2 rounded-lg p-2 ${
+                    showWinnerSelect ? "cursor-pointer hover:bg-royal-50" : "bg-surface"
+                  } ${selectedBidId === bid.id ? "bg-royal-100 ring-2 ring-royal" : ""}`}
+                  onClick={() => showWinnerSelect && setSelectedBidId(bid.id)}
                 >
                   <Avatar name={bid.userName} src={bid.userAvatar} size="sm" />
                   <div className="flex-1 min-w-0">
@@ -290,31 +419,90 @@ export default function TaskDetailPage() {
             </div>
           )}
 
-          {/* Place bid */}
-          <div className="space-y-2">
-            <Input
-              label="Your bid (points)"
-              type="number"
-              placeholder={`Lower than ${lowestBid}`}
-              value={bidAmount}
-              onChange={(e) => setBidAmount(e.target.value)}
-            />
-            <Input
-              label="Trash talk (optional)"
-              placeholder="I'm already at Walgreens..."
-              value={bidComment}
-              onChange={(e) => setBidComment(e.target.value)}
-            />
-            <Button
-              className="w-full"
-              loading={submitting}
-              onClick={handleBid}
-              disabled={!bidAmount || parseInt(bidAmount) >= lowestBid}
-            >
-              <Gavel className="w-4 h-4" />
-              Place Bid
-            </Button>
-          </div>
+          {/* Card Holder Controls */}
+          {isCardHolder && !auctionExpired && !showWinnerSelect && task.bids.length > 0 && (
+            <div className="space-y-2 mb-4">
+              <p className="text-xs text-muted font-semibold">Card Holder Controls</p>
+              <div className="flex gap-2">
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  size="sm"
+                  onClick={handleCloseAuctionAuto}
+                  loading={submitting}
+                >
+                  <Award className="w-4 h-4" />
+                  Award Lowest
+                </Button>
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  size="sm"
+                  onClick={() => setShowWinnerSelect(true)}
+                >
+                  <UserCheck className="w-4 h-4" />
+                  Select Winner
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Winner Selection Mode */}
+          {showWinnerSelect && (
+            <div className="space-y-2 mb-4">
+              <p className="text-sm font-semibold text-midnight">
+                Select a winner from the bids above
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="secondary"
+                  className="flex-1"
+                  onClick={() => {
+                    setShowWinnerSelect(false);
+                    setSelectedBidId(null);
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  className="flex-1"
+                  onClick={handleSelectWinner}
+                  disabled={!selectedBidId}
+                  loading={submitting}
+                >
+                  Confirm Winner
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {/* Place bid (non-Card Holders only) */}
+          {!isCardHolder && !auctionExpired && (
+            <div className="space-y-2">
+              <Input
+                label="Your bid (points)"
+                type="number"
+                placeholder={`Lower than ${lowestBid}`}
+                value={bidAmount}
+                onChange={(e) => setBidAmount(e.target.value)}
+              />
+              <Input
+                label="Trash talk (optional)"
+                placeholder="I'm already at Walgreens..."
+                value={bidComment}
+                onChange={(e) => setBidComment(e.target.value)}
+              />
+              <Button
+                className="w-full"
+                loading={submitting}
+                onClick={handleBid}
+                disabled={!bidAmount || parseInt(bidAmount) >= lowestBid}
+              >
+                <Gavel className="w-4 h-4" />
+                Place Bid
+              </Button>
+            </div>
+          )}
         </Card>
       )}
 

--- a/src/app/api/tasks/[id]/bid/route.ts
+++ b/src/app/api/tasks/[id]/bid/route.ts
@@ -63,6 +63,40 @@ export async function POST(
 
     const settings = task.auctionSettings as AuctionSettings;
     if (settings?.endsAt && new Date(settings.endsAt) < new Date()) {
+      // Auction has expired - auto-close it by awarding to lowest bidder
+      const lowestBid = db
+        .select()
+        .from(bids)
+        .where(eq(bids.taskId, taskId))
+        .orderBy(bids.bidAmount)
+        .limit(1)
+        .get();
+
+      if (lowestBid) {
+        db.update(tasks)
+          .set({
+            status: "claimed",
+            claimedBy: lowestBid.userId,
+            finalPointCost: lowestBid.bidAmount,
+          })
+          .where(eq(tasks.id, taskId))
+          .run();
+
+        logActivity(task.crewId, "auction_won", lowestBid.userId, {
+          taskId: task.id,
+          taskTitle: task.title,
+          winningBid: lowestBid.bidAmount,
+        });
+
+        notifyOnEvent(task.crewId, "auction_won", lowestBid.userId, {
+          taskId: task.id,
+          taskTitle: task.title,
+          winningBid: lowestBid.bidAmount,
+          winnerId: lowestBid.userId,
+          actorName: "System",
+        });
+      }
+
       return NextResponse.json(
         { error: "This auction has ended" },
         { status: 409 }

--- a/src/app/api/tasks/[id]/check-auction/route.ts
+++ b/src/app/api/tasks/[id]/check-auction/route.ts
@@ -1,0 +1,110 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { tasks, bids } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { uuidParamSchema } from "@/lib/validators";
+import { logActivity } from "@/lib/points";
+import { notifyOnEvent } from "@/lib/notification-service";
+
+type AuctionSettings = {
+  endsAt?: string;
+  minBid?: number;
+  autoCloseAfterBids?: number | null;
+} | null;
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: taskId } = await params;
+    const parsedId = uuidParamSchema.safeParse(taskId);
+    if (!parsedId.success) {
+      return NextResponse.json({ error: "Invalid task ID" }, { status: 400 });
+    }
+
+    const task = db.select().from(tasks).where(eq(tasks.id, taskId)).get();
+
+    if (!task) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+
+    if (task.requestMode !== "auction") {
+      return NextResponse.json(
+        { error: "This task is not an auction" },
+        { status: 400 }
+      );
+    }
+
+    const settings = task.auctionSettings as AuctionSettings;
+    const now = new Date();
+    const endsAt = settings?.endsAt ? new Date(settings.endsAt) : null;
+    const isExpired = endsAt && endsAt < now;
+
+    // If expired and still pending, auto-close it
+    if (isExpired && task.status === "pending") {
+      const lowestBid = db
+        .select()
+        .from(bids)
+        .where(eq(bids.taskId, taskId))
+        .orderBy(bids.bidAmount)
+        .limit(1)
+        .get();
+
+      if (lowestBid) {
+        db.update(tasks)
+          .set({
+            status: "claimed",
+            claimedBy: lowestBid.userId,
+            finalPointCost: lowestBid.bidAmount,
+          })
+          .where(eq(tasks.id, taskId))
+          .run();
+
+        logActivity(task.crewId, "auction_won", lowestBid.userId, {
+          taskId: task.id,
+          taskTitle: task.title,
+          winningBid: lowestBid.bidAmount,
+          autoClosedOnExpiry: true,
+        });
+
+        notifyOnEvent(task.crewId, "auction_won", lowestBid.userId, {
+          taskId: task.id,
+          taskTitle: task.title,
+          winningBid: lowestBid.bidAmount,
+          winnerId: lowestBid.userId,
+          actorName: "System",
+        });
+
+        return NextResponse.json({
+          status: "closed",
+          expired: true,
+          endsAt: endsAt?.toISOString(),
+          winner: {
+            userId: lowestBid.userId,
+            bidAmount: lowestBid.bidAmount,
+          },
+        });
+      }
+    }
+
+    return NextResponse.json({
+      status: task.status === "pending" ? (isExpired ? "expired" : "active") : task.status,
+      expired: isExpired || false,
+      endsAt: endsAt?.toISOString() || null,
+      timeRemaining: endsAt && !isExpired ? Math.max(0, endsAt.getTime() - now.getTime()) : 0,
+    });
+  } catch (error) {
+    console.error("Check auction error:", error);
+    return NextResponse.json(
+      { error: "Failed to check auction status" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/tasks/[id]/close-auction/route.ts
+++ b/src/app/api/tasks/[id]/close-auction/route.ts
@@ -1,0 +1,166 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { tasks, bids, crewMembers } from "@/db/schema";
+import { eq, and } from "drizzle-orm";
+import { z } from "zod";
+import { uuidParamSchema } from "@/lib/validators";
+import { logActivity } from "@/lib/points";
+import { notifyOnEvent } from "@/lib/notification-service";
+
+const closeAuctionSchema = z.object({
+  action: z.enum(["auto", "select"]),
+  bidId: z.string().uuid().optional(),
+});
+
+export async function POST(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: taskId } = await params;
+    const parsedId = uuidParamSchema.safeParse(taskId);
+    if (!parsedId.success) {
+      return NextResponse.json({ error: "Invalid task ID" }, { status: 400 });
+    }
+
+    const task = db.select().from(tasks).where(eq(tasks.id, taskId)).get();
+
+    if (!task) {
+      return NextResponse.json({ error: "Task not found" }, { status: 404 });
+    }
+
+    if (task.requestMode !== "auction") {
+      return NextResponse.json(
+        { error: "This task is not an auction" },
+        { status: 400 }
+      );
+    }
+
+    if (task.status !== "pending") {
+      return NextResponse.json(
+        { error: "This auction is no longer active" },
+        { status: 409 }
+      );
+    }
+
+    // Check if user is Card Holder or Admin
+    const membership = db
+      .select()
+      .from(crewMembers)
+      .where(
+        and(
+          eq(crewMembers.crewId, task.crewId),
+          eq(crewMembers.userId, session.user.id)
+        )
+      )
+      .get();
+
+    if (!membership || (membership.role !== "card_holder" && membership.role !== "admin")) {
+      return NextResponse.json(
+        { error: "Only Card Holder or Admin can close auctions" },
+        { status: 403 }
+      );
+    }
+
+    const body = await request.json();
+    const parsed = closeAuctionSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0].message },
+        { status: 400 }
+      );
+    }
+
+    let winningBid;
+
+    if (parsed.data.action === "auto") {
+      // Award to lowest bidder
+      winningBid = db
+        .select()
+        .from(bids)
+        .where(eq(bids.taskId, taskId))
+        .orderBy(bids.bidAmount)
+        .limit(1)
+        .get();
+    } else if (parsed.data.action === "select") {
+      // Award to specific bid
+      if (!parsed.data.bidId) {
+        return NextResponse.json(
+          { error: "bidId is required for select action" },
+          { status: 400 }
+        );
+      }
+
+      winningBid = db
+        .select()
+        .from(bids)
+        .where(
+          and(eq(bids.taskId, taskId), eq(bids.id, parsed.data.bidId))
+        )
+        .get();
+
+      if (!winningBid) {
+        return NextResponse.json(
+          { error: "Bid not found" },
+          { status: 404 }
+        );
+      }
+    }
+
+    if (!winningBid) {
+      return NextResponse.json(
+        { error: "No bids available to award" },
+        { status: 400 }
+      );
+    }
+
+    // Update task status
+    const updatedTask = db
+      .update(tasks)
+      .set({
+        status: "claimed",
+        claimedBy: winningBid.userId,
+        finalPointCost: winningBid.bidAmount,
+      })
+      .where(eq(tasks.id, taskId))
+      .returning()
+      .get();
+
+    // Log activity
+    logActivity(task.crewId, "auction_won", winningBid.userId, {
+      taskId: task.id,
+      taskTitle: task.title,
+      winningBid: winningBid.bidAmount,
+      closedBy: session.user.id,
+      closedManually: true,
+    });
+
+    // Notify winner
+    notifyOnEvent(task.crewId, "auction_won", winningBid.userId, {
+      taskId: task.id,
+      taskTitle: task.title,
+      winningBid: winningBid.bidAmount,
+      winnerId: winningBid.userId,
+      actorName: session.user.name || "Card Holder",
+    });
+
+    return NextResponse.json({
+      success: true,
+      task: updatedTask,
+      winningBid,
+    });
+  } catch (error) {
+    console.error("Close auction error:", error);
+    return NextResponse.json(
+      { error: "Failed to close auction" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Auctions previously had no way to close unless `autoCloseAfterBids` was set. This PR adds proper auction lifecycle management.

## Changes

### New API Endpoints
- **`POST /api/tasks/[id]/close-auction`** — Card Holder manually closes an auction
  - `{ action: "auto" }` — awards to lowest bidder
  - `{ action: "select", bidId: "..." }` — awards to a specific bid
- **`GET /api/tasks/[id]/check-auction`** — Returns auction status (active/expired/closed), auto-closes if deadline passed

### Modified
- **Bid route** (`/api/tasks/[id]/bid`) — rejects bids on expired auctions, auto-closes and awards lowest bidder
- **Play Card UI** — duration selector (30m, 1hr, 2hr, 4hr, 8hr, 24hr) replaces hardcoded 60min default
- **Task Detail UI** — real-time countdown timer, Card Holder controls:
  - "Award Lowest Bid" button (instant close)
  - "Select Winner" with bid selection UI
  - Auto-refresh when auction expires while viewing

### Migration
- `drizzle/0002_auction_close.sql` — documentation only (no schema changes; `endsAt` already exists in `auctionSettings` JSON)

## How It Works
1. When a Card Holder plays an auction card, `endsAt` is computed from the selected duration
2. Crew members bid down — bids are rejected after deadline
3. Auction closes via: deadline expiry (auto), Card Holder manual close, or `autoCloseAfterBids` threshold
4. Card Holder can override auto-close and pick any bidder

## Testing
- TypeScript: `tsc --noEmit` passes clean
- Covers roadmap item 2.7 (Auction countdown timer)

## Related
Roadmap Phase 2 — Polish and UX Improvements